### PR TITLE
Reduce heading line height

### DIFF
--- a/css/dev/global.css
+++ b/css/dev/global.css
@@ -248,8 +248,8 @@ img {
   --typography-paragraph-size: var(--typography-size-18);
   --typography-nav-toggle-label-size: var(--typography-size-16);
   --typography-captions-size: var(--typography-size-16);
-  --typography-heading-line-height: 1.5;
-  --typography-heading-core-line-height: 1.5;
+  --typography-heading-line-height: 1.2;
+  --typography-heading-core-line-height: 1.2;
   --typography-paragraph-line-height: 1.7;
   --typography-weight-regular: 400;
   --typography-weight-medium: 500;


### PR DESCRIPTION
Reduces heading line height from `1.5` to `1.2` for improved readability.

### Before
<img width="963" height="225" alt="image" src="https://github.com/user-attachments/assets/baddff74-874e-4fda-adfa-95660e8f4e92" />

### After

<img width="946" height="136" alt="image" src="https://github.com/user-attachments/assets/1d505995-dea7-42f6-875f-0bd346dad89c" />


